### PR TITLE
Fix overlapping animation in hero image slider #120

### DIFF
--- a/src/components/HeroSmoothSlider.astro
+++ b/src/components/HeroSmoothSlider.astro
@@ -56,13 +56,13 @@ const images = [
     0% {
       opacity: 0;
     }
-    10% {
+    5% {
       opacity: 1;
     }
-    30% {
+    15% {
       opacity: 1;
     }
-    40% {
+    16.6667% {
       opacity: 0;
     }
     100% {


### PR DESCRIPTION
# Description

Problem: The hero image slider animation overlapped on the second iteration. The first image started fading out while the last image was still fading out, causing a visual glitch.

Solution: Updated the keyframes animation setting so each image fades in and out sequentially without overlapping, resulting in smoother transitions.

| Title                         | Value                                                        |
| ----------------------------- | ------------------------------------------------------------ |
| **Type**                      | Bugfix  |
| **Related Issue**             | #120                                             |
| **ENV&nbsp;vars&nbsp;change** | No        |
| **Local&nbsp;testing**        | Pending / Done                                               |
| **Staging&nbsp;testing**      | Pending / Skip / Not Required                                |

---
